### PR TITLE
Improve copy / paste behaviour

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.x.y (NOT RELEASED YET)
 
-- ...
+- Do not capture mouse input in order to facilitate copying from terminal.
+- Improve UI responsiveness when pasting.
 
 # 0.2.3
 

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 use termion::clear;
 use termion::cursor::Goto;
 use termion::event::Key;
-use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
@@ -70,7 +69,6 @@ fn main() -> Result<(), failure::Error> {
 
     // Configure the terminal...
     let stdout = io::stdout().into_raw_mode()?;
-    let stdout = MouseTerminal::from(stdout);
     let stdout = AlternateScreen::from(stdout);
     let backend = TermionBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;

--- a/client/src/tab.rs
+++ b/client/src/tab.rs
@@ -44,6 +44,11 @@ impl Tab {
         Ok(())
     }
 
+    fn add_read(&mut self, message: String) -> Result<(), String> {
+        self.view.add(message);
+        Ok(())
+    }
+
     fn title(&self) -> Text {
         let mut modifier = Modifier::empty();
         if self.has_unread {
@@ -112,7 +117,7 @@ impl Tabs {
 
     pub fn add_current(&mut self, msg: String) -> Result<(), String> {
         if let Some(tab) = self.tabs.get_mut(self.current_tab) {
-            tab.add(msg)
+            tab.add_read(msg)
         } else {
             Err("No current tab?".to_string())
         }

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -3,43 +3,22 @@
 use std::io;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 use termion::event::Key;
 use termion::input::TermRead;
 
 pub enum Event<I> {
     Input(I),
-    Tick,
 }
 
-/// A small event handler that wrap termion input and tick events. Each event
-/// type is handled in its own thread and returned to a common `Receiver`
+/// A small event handler that wrap termion input events.
 pub struct Events {
     rx: mpsc::Receiver<Event<Key>>,
     input_handle: thread::JoinHandle<()>,
-    tick_handle: thread::JoinHandle<()>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Config {
-    pub tick_rate: Duration,
-}
-
-impl Default for Config {
-    fn default() -> Config {
-        Config {
-            tick_rate: Duration::from_millis(250),
-        }
-    }
 }
 
 impl Events {
     pub fn new() -> Events {
-        Events::with_config(Config::default())
-    }
-
-    pub fn with_config(config: Config) -> Events {
         let (tx, rx) = mpsc::channel();
         let input_handle = {
             let tx = tx.clone();
@@ -54,23 +33,10 @@ impl Events {
                 }
             })
         };
-        let tick_handle = {
-            thread::spawn(move || {
-                let tx = tx.clone();
-                loop {
-                    tx.send(Event::Tick).unwrap();
-                    thread::sleep(config.tick_rate);
-                }
-            })
-        };
-        Events {
-            rx,
-            input_handle,
-            tick_handle,
-        }
+        Events { rx, input_handle }
     }
 
-    pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
-        self.rx.recv()
+    pub fn next(&self) -> Result<Event<Key>, mpsc::TryRecvError> {
+        self.rx.try_recv()
     }
 }

--- a/icb/src/lib.rs
+++ b/icb/src/lib.rs
@@ -206,44 +206,28 @@ impl Server {
                         Command::Open(msg) => {
                             q("Sending message to channel", &msg).unwrap();
                             let packet = (packets::OPEN.create)(vec![msg.as_str()]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Personal(recipient, msg) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_MSG,
                                 format!("{} {}", recipient, msg).as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Beep(recipient) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_BEEP,
                                 recipient.as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Name(newname) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_NAME,
                                 newname.as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                             self.nickname = newname;
                         }
                     }
@@ -294,10 +278,7 @@ impl Server {
             "login",
         ]);
 
-        self.sock
-            .as_ref()
-            .unwrap()
-            .write_all(&login_packet)?;
+        self.sock.as_ref().unwrap().write_all(&login_packet)?;
 
         if self.read(Some(packets::T_LOGIN)).is_err() {
             panic!("Login failed.");

--- a/icb/src/packets.rs
+++ b/icb/src/packets.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::str;
 use std::convert::TryFrom;
+use std::str;
 
 use crate::util::q;
 


### PR DESCRIPTION
This shuffles things around a little bit to make the UI respond a bit better when copy / pasting. We can read multiple events off the Event channel in a single frame update, and use the channel Empty Err type to indicate nothing more to read. By doing all Event/IO at the top of the loop, we can move redrawing bit to the bottom and only redraw if something has actually changed. This also lets us remove Event::Tick, which was previously driving the UI at least once every 250ms.