### PR TITLE
Input handling

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.x.y (NOT RELEASED YET)
 
-- ...
+- Do not capture mouse input in order to facilitate copying from terminal.
+- Improve UI responsiveness when pasting.
 
 # 0.2.3
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Do not capture mouse input in order to facilitate copying from terminal.
 - Improve UI responsiveness when pasting.
+- Improve input handling.
 
 # 0.2.3
 

--- a/client/src/input.rs
+++ b/client/src/input.rs
@@ -1,0 +1,257 @@
+use std::ops::{Deref, DerefMut};
+use unicode_width::UnicodeWidthChar;
+
+/// A structure that holds input strings
+pub struct History {
+    /// The list of all history
+    history: Vec<Input>,
+    /// Current index
+    index: usize,
+}
+
+impl History {
+    /// Make a new history struct
+    pub fn new() -> Self {
+        let mut h = History {
+            history: Vec::with_capacity(100),
+            index: 0,
+        };
+        h.history.push(Input::new());
+        h
+    }
+
+    /// Increment the history to the next Input
+    pub fn next(&mut self) {
+        let max = match self.history.len().checked_sub(1) {
+            Some(n) => n,
+            None => 0,
+        };
+        self.index = match self.index.checked_add(1) {
+            Some(n) => std::cmp::min(n, max),
+            None => max,
+        }
+    }
+
+    /// Decrement the history to the previous Input
+    pub fn prev(&mut self) {
+        self.index = match self.index.checked_sub(1) {
+            Some(n) => n,
+            None => 0,
+        }
+    }
+
+    /// Append a new Input to the list and set it to the current input
+    pub fn new_line(&mut self) {
+        // Don't make a new entry if the last one is already empty
+        let makenew = if let Some(input) = self.history.last() {
+            !input.buffer.is_empty()
+        } else {
+            true
+        };
+
+        if makenew {
+            self.history.push(Input::new());
+        }
+
+        self.index = match self.history.len().checked_sub(1) {
+            Some(n) => n,
+            None => 0,
+        }
+    }
+}
+
+impl Deref for History {
+    type Target = Input;
+
+    fn deref(&self) -> &Self::Target {
+        self.history.get(self.index).unwrap()
+    }
+}
+
+impl DerefMut for History {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.history.get_mut(self.index).unwrap()
+    }
+}
+
+/// A struct that holds user input
+pub struct Input {
+    /// The input buffer
+    buffer: Vec<char>,
+    /// The current cursor position
+    cursor: usize,
+}
+
+impl Input {
+    /// Make new Input
+    pub fn new() -> Self {
+        Input {
+            buffer: Vec::with_capacity(0),
+            cursor: 0,
+        }
+    }
+
+    /// Return a clone of the input buffer
+    pub fn get_string(&self) -> String {
+        self.buffer.iter().collect()
+    }
+
+    /// Return a view of the input that contains the cursor.
+    /// Returns a tuple (data: String, cursor: usize) where the
+    /// cursor is always within the provided view.
+    pub fn view(&self, width: usize) -> (String, usize) {
+        let quarter = match width.checked_div(4) {
+            Some(m) => m,
+            None => 1,
+        };
+
+        let max_cols = 3 * quarter;
+        let mut want_cols = max_cols;
+        let mut start_pos = self.cursor;
+        while start_pos > 0 && want_cols > 0 {
+            start_pos -= 1;
+            if let Some(c) = self.buffer.get(start_pos) {
+                if let Some(w) = UnicodeWidthChar::width(*c) {
+                    want_cols = match want_cols.checked_sub(w) {
+                        Some(new) => new,
+                        None => 0,
+                    }
+                }
+            }
+        }
+
+        let ret: String = self.buffer.iter().skip(start_pos).collect();
+        (ret, max_cols - want_cols)
+    }
+
+    /// Set the cursor value to the given value or the maximum
+    /// possible value at the end of the buffer.
+    fn set_cursor(&mut self, new: usize) {
+        let max = self.buffer.len();
+        self.cursor = std::cmp::min(max, new);
+    }
+
+    /// Add a character to the buffer
+    pub fn insert(&mut self, c: char) {
+        self.buffer.insert(self.cursor, c);
+        self.set_cursor(self.cursor.wrapping_add(1));
+    }
+
+    /// Delete a character from the buffer and decrement the cursor
+    pub fn backspace(&mut self) {
+        loop {
+            if let Some(n) = self.cursor.checked_sub(1) {
+                let removed = self.buffer.remove(n);
+                self.cursor = n;
+                match UnicodeWidthChar::width(removed) {
+                    // Keep backspacing while we're deleting zero-width chars
+                    Some(width) if width == 0 => continue,
+                    _ => break,
+                }
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Delete a character from the buffer and do not decrement the cursor
+    pub fn delete(&mut self) {
+        loop {
+            if let None = self.buffer.get(self.cursor) {
+                break;
+            }
+            self.buffer.remove(self.cursor);
+            self.set_cursor(self.cursor);
+            if !self.is_zero_width(self.cursor) {
+                break;
+            }
+        }
+    }
+
+    /// Get the character before the cursor
+    fn prev_char(&self) -> Option<&char> {
+        match self.cursor.checked_sub(1) {
+            Some(n) => self.buffer.get(n),
+            None => None,
+        }
+    }
+
+    /// Delete from cursor to end of previous word
+    pub fn backspace_word(&mut self) {
+        // If we are already on whitespace, back up to the prev word
+        loop {
+            match self.prev_char() {
+                Some(c) => {
+                    if c.is_whitespace() {
+                        self.backspace();
+                    } else {
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+
+        // Now delete the word
+        loop {
+            match self.prev_char() {
+                Some(c) => {
+                    if c.is_whitespace() {
+                        break;
+                    } else {
+                        self.backspace();
+                    }
+                }
+                None => break,
+            }
+        }
+    }
+
+    /// Return true if the char at the index exists and is zero width
+    fn is_zero_width(&self, index: usize) -> bool {
+        if let Some(c) = self.buffer.get(index) {
+            if let Some(w) = UnicodeWidthChar::width(*c) {
+                if w == 0 {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /// Move the cursor the the right
+    pub fn move_right(&mut self, num: usize) {
+        loop {
+            match self.cursor.checked_add(num) {
+                Some(n) => self.set_cursor(n),
+                None => break,
+            };
+            if !self.is_zero_width(self.cursor) {
+                break;
+            }
+        }
+    }
+
+    /// Move the cursor to the left
+    pub fn move_left(&mut self, num: usize) {
+        loop {
+            self.cursor = match self.cursor.checked_sub(num) {
+                Some(n) => n,
+                None => 0,
+            };
+            if self.cursor == 0 || !self.is_zero_width(self.cursor) {
+                break;
+            }
+        }
+    }
+
+    /// Move to the end of the input
+    pub fn move_to_end(&mut self) {
+        self.set_cursor(self.buffer.len());
+    }
+
+    /// Move to the start of the input
+    pub fn move_to_start(&mut self) {
+        self.cursor = 0;
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -15,7 +15,6 @@ use std::time::Duration;
 use termion::clear;
 use termion::cursor::Goto;
 use termion::event::Key;
-use termion::input::MouseTerminal;
 use termion::raw::IntoRawMode;
 use termion::screen::AlternateScreen;
 use tui::backend::TermionBackend;
@@ -70,7 +69,6 @@ fn main() -> Result<(), failure::Error> {
 
     // Configure the terminal...
     let stdout = io::stdout().into_raw_mode()?;
-    let stdout = MouseTerminal::from(stdout);
     let stdout = AlternateScreen::from(stdout);
     let backend = TermionBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;

--- a/client/src/tab.rs
+++ b/client/src/tab.rs
@@ -44,6 +44,11 @@ impl Tab {
         Ok(())
     }
 
+    fn add_read(&mut self, message: String) -> Result<(), String> {
+        self.view.add(message);
+        Ok(())
+    }
+
     fn title(&self) -> Text {
         let mut modifier = Modifier::empty();
         if self.has_unread {
@@ -112,7 +117,7 @@ impl Tabs {
 
     pub fn add_current(&mut self, msg: String) -> Result<(), String> {
         if let Some(tab) = self.tabs.get_mut(self.current_tab) {
-            tab.add(msg)
+            tab.add_read(msg)
         } else {
             Err("No current tab?".to_string())
         }

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -3,43 +3,22 @@
 use std::io;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 use termion::event::Key;
 use termion::input::TermRead;
 
 pub enum Event<I> {
     Input(I),
-    Tick,
 }
 
-/// A small event handler that wrap termion input and tick events. Each event
-/// type is handled in its own thread and returned to a common `Receiver`
+/// A small event handler that wrap termion input events.
 pub struct Events {
     rx: mpsc::Receiver<Event<Key>>,
     input_handle: thread::JoinHandle<()>,
-    tick_handle: thread::JoinHandle<()>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub struct Config {
-    pub tick_rate: Duration,
-}
-
-impl Default for Config {
-    fn default() -> Config {
-        Config {
-            tick_rate: Duration::from_millis(250),
-        }
-    }
 }
 
 impl Events {
     pub fn new() -> Events {
-        Events::with_config(Config::default())
-    }
-
-    pub fn with_config(config: Config) -> Events {
         let (tx, rx) = mpsc::channel();
         let input_handle = {
             let tx = tx.clone();
@@ -54,23 +33,10 @@ impl Events {
                 }
             })
         };
-        let tick_handle = {
-            thread::spawn(move || {
-                let tx = tx.clone();
-                loop {
-                    tx.send(Event::Tick).unwrap();
-                    thread::sleep(config.tick_rate);
-                }
-            })
-        };
-        Events {
-            rx,
-            input_handle,
-            tick_handle,
-        }
+        Events { rx, input_handle }
     }
 
-    pub fn next(&self) -> Result<Event<Key>, mpsc::RecvError> {
-        self.rx.recv()
+    pub fn next(&self) -> Result<Event<Key>, mpsc::TryRecvError> {
+        self.rx.try_recv()
     }
 }

--- a/icb/src/lib.rs
+++ b/icb/src/lib.rs
@@ -206,44 +206,28 @@ impl Server {
                         Command::Open(msg) => {
                             q("Sending message to channel", &msg).unwrap();
                             let packet = (packets::OPEN.create)(vec![msg.as_str()]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Personal(recipient, msg) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_MSG,
                                 format!("{} {}", recipient, msg).as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Beep(recipient) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_BEEP,
                                 recipient.as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                         }
                         Command::Name(newname) => {
                             let packet = (packets::COMMAND.create)(vec![
                                 packets::CMD_NAME,
                                 newname.as_str(),
                             ]);
-                            self.sock
-                                .as_ref()
-                                .unwrap()
-                                .write_all(&packet)
-                                .unwrap();
+                            self.sock.as_ref().unwrap().write_all(&packet).unwrap();
                             self.nickname = newname;
                         }
                     }
@@ -294,10 +278,7 @@ impl Server {
             "login",
         ]);
 
-        self.sock
-            .as_ref()
-            .unwrap()
-            .write_all(&login_packet)?;
+        self.sock.as_ref().unwrap().write_all(&login_packet)?;
 
         if self.read(Some(packets::T_LOGIN)).is_err() {
             panic!("Login failed.");

--- a/icb/src/packets.rs
+++ b/icb/src/packets.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
-use std::str;
 use std::convert::TryFrom;
+use std::str;
 
 use crate::util::q;
 


### PR DESCRIPTION
Includes changes from #5. The last commit includes all of the input handling changes.

Move input to its own module to make it easy to handle moving the cursor around and scrolling history. Implemented in a unicode aware way.

Fixes input of long lines and deleting characters from the middle of the input string. While there, add support for Delete, and implement ^W deleting the last word.