### PR TITLE
Improve packet parsing error handling.

### DIFF
--- a/icb/CHANGELOG.md
+++ b/icb/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.x.y (NOT RELEASED YET)
+
+- Do not panic on invalid packets or non-utf8 payloads.
+
 # 0.2.2
 
 - implement sending `beep` commands and receiving `beep` messages

--- a/icb/src/lib.rs
+++ b/icb/src/lib.rs
@@ -159,7 +159,7 @@ impl Server {
         q("Looking for a packet of type", &packet_type_byte)?;
         for packet in &packets::PACKETS {
             if packet.packet_type == packet_type_byte {
-                let data = (packet.parse)(message, packet_len);
+                let data = (packet.parse)(message, packet_len)?;
                 q("data", &data)?;
 
                 return Ok(data);


### PR DESCRIPTION
Do not assume the received packet has the expected number of fields
or is utf8 safe. Change packet parsing functions to return a Result,
which lets us plumb errors back up to the caller to handle. Use lossy
utf8 conversion to handle non-utf8 payloads.