### PR TITLE
Add ScrollLock indicator for each tab.

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -340,7 +340,11 @@ fn main() -> Result<(), failure::Error> {
                         ui.views.draw_current(&mut f, chunks[1]);
 
                         Paragraph::new([Text::raw(input_str)].iter())
-                            .block(Block::default().borders(Borders::TOP))
+                            .block(
+                                Block::default()
+                                    .title(&ui.views.status_line())
+                                    .borders(Borders::TOP),
+                            )
                             .render(&mut f, chunks[2]);
                     })
                     .expect("Failed to draw UI to terminal");

--- a/client/src/tab.rs
+++ b/client/src/tab.rs
@@ -231,4 +231,12 @@ impl Tabs {
             t.view.toggle_autoscroll();
         }
     }
+
+    pub fn status_line(&self) -> String {
+        if let Some(t) = self.tabs.get(self.current_tab) {
+            t.view.status_line()
+        } else {
+            String::new()
+        }
+    }
 }

--- a/client/src/tailview.rs
+++ b/client/src/tailview.rs
@@ -192,4 +192,12 @@ impl TailView {
     pub fn toggle_autoscroll(&mut self) {
         self.options.autoscroll = !self.options.autoscroll;
     }
+
+    pub fn status_line(&self) -> String {
+        let mut s = String::new();
+        if !self.options.autoscroll {
+            s.push('S');
+        }
+        s
+    }
 }


### PR DESCRIPTION
Minor improvement to add an indicator for whether or not the current view has scroll lock enabled.